### PR TITLE
fix/issue_4: Fix operator on whereHas case

### DIFF
--- a/src/Elfif/MetaSearch_L5/Operation.php
+++ b/src/Elfif/MetaSearch_L5/Operation.php
@@ -70,7 +70,12 @@ class Operation
                 }
                 break;
             case Field::WHEREHAS:
-                $firstOperator = ($or) ? "orWhereHas" : "whereHas" ;
+                if ($this->or) {
+                    $firstOperator = "orWhereHas";
+                    $operator = 'where';
+                } else {
+                    $firstOperator = 'whereHas';
+                }
 
                 if (isset($operand) && isset($this->value)) {
                     $this->query->$firstOperator($field->relation, function($query) use ($field, $operand, $operator){


### PR DESCRIPTION
The parameter q[name_or_contacts.name_equals]=test generates the following query, which is incorrect: 

`select * from vendors where (name= ‘test’ and exists (select * from contacts where (vendors.id=contacts.vendor_id or (name = ‘test’)); .`

In that query, the conjunction operator is and, but should be or.

This is a fix to correct the query generated by such parameters